### PR TITLE
Fix r_snapshot.sh: pass force=TRUE so partial libraries snapshot

### DIFF
--- a/templates/r_snapshot.sh
+++ b/templates/r_snapshot.sh
@@ -50,6 +50,10 @@ mkdir -p "${RENV_TOOLS_LIB}"
 
 # Record the current project library (R_LIBS_USER) into env_setup/renv.lock.
 # type="all" captures every installed package, not just those referenced by code.
+# force=TRUE bypasses renv's pre-flight validation: a researcher's copied library
+# is typically partial (some transitive dependencies aren't present), which would
+# otherwise abort the snapshot. We only want to *record* what's there, so we write
+# the lockfile regardless of an incomplete dependency closure.
 Rscript -e '
   tools <- Sys.getenv("RENV_TOOLS_LIB")
   proj  <- Sys.getenv("R_LIBS_USER")
@@ -59,7 +63,7 @@ Rscript -e '
   library(renv, lib.loc = tools)
   renv::snapshot(library = proj, type = "all",
                  lockfile = file.path("env_setup", "renv.lock"),
-                 prompt = FALSE)
+                 prompt = FALSE, force = TRUE)
 '
 
 printf "\nWrote env_setup/renv.lock (manifest of %s).\n" "${R_LIBS_USER}"


### PR DESCRIPTION
renv::snapshot(type="all") runs a pre-flight validation requiring the full
dependency closure to be present, and aborts otherwise. A researcher's copied
R library is typically partial (some transitive dependencies are absent), so
the snapshot failed with "aborting snapshot due to pre-flight validation
failure".

We use renv only to record what was reproduced, not to guarantee a consistent
closure, so pass force=TRUE to write the lockfile regardless. Verified against
a partial library (zoo without its lattice dependency): snapshot now succeeds
and records the installed package.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
