### PR TITLE
Add Gotchas section + reproduction gate from INC20924136 retrospective

### DIFF
--- a/.claude/commands/init-request.md
+++ b/.claude/commands/init-request.md
@@ -14,7 +14,9 @@ Do the following, then stop and report:
    TRIAGE="$(dirname "$(readlink -f .claude)")/bin/triage_build_log.sh"
    "$TRIAGE" context/logs/<log>
    ```
-   (or invoke the `triage-build-log` skill, which does the same). Record each log's classification + key finding. If the triage shows an **R package install failure**, recommend the **`r-install-debugger`** agent as the next step (don't run it yourself here).
+   (or invoke the `triage-build-log` skill, which does the same). Record each log's classification + key finding. If the triage shows an **R package install failure**, recommend the **`r-install-debugger`** agent as the next step (don't run it yourself here) — **but gate that recommendation per the rule below**.
+   - **Before recommending any compile-heavy reproduction** (e.g. the `r-install-debugger` agent), check whether `context/` actually contains the researcher's **exact command** and **verbatim error text / screenshot**. If either is missing, your top recommended next step is to *ask the facilitator for them* — not to reproduce. The actual command and error are cheap and frequently reveal a shallow root cause (wrong/missing package name, stale `00LOCK`, non-writeable library, wrong repo) that needs no compilation.
+   - **Diagnose cheap → expensive.** Order: (1) read the exact command + error, (2) check for stale `00LOCK-*` dirs and library write-permission issues, (3) only then run the `r-install-debugger` agent to reproduce a genuine build/compile failure.
 5. **Environment** — Read `./module_load.sh` (modules, `R_LIBS_USER`, toolset PATH, cache/config isolation) and, if present, `./env_setup/renv.lock` (reproduced R package versions). Note the version(s) and any packages relevant to the issue.
 6. **Write the summary** — Create or update `./context/SUMMARY.md` with these sections:
    - **Problem** — concise statement of the issue (from `context/`).
@@ -23,5 +25,7 @@ Do the following, then stop and report:
    - **Logs** — for each log in `context/logs/`: what it is, and the triage classification / key finding (not the raw log).
    - **Links / References** — from `context/links.md`.
    - **Open questions** — what's unclear or needs the facilitator's input.
+
+   Treat `SUMMARY.md` as a living document, but when new evidence *contradicts* an earlier finding, **replace** the stale section rather than appending a new one — don't leave the file holding both the old guess and the new fact. If several sections are now wrong, rewrite the whole file once instead of layering many partial edits.
 
 Then give me a short (5–10 line) summary of the request and ask which part to investigate first. Do not start changing the researcher's scripts yet.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -35,3 +35,10 @@ From the symlinked `.claude/` and (once you `source module_load.sh`) the `bin/<l
 - The reproduced library is a **faithful copy** of the researcher's environment (same cluster, same R version/arch) — treat package versions as fixed evidence, not something to "fix" by upgrading, unless that is the diagnosis.
 - `renv.lock` is the audit record of what was reproduced; consult it to reason about package versions.
 - Don't write outside this workspace; don't modify the facilitator's home directory.
+
+## Gotchas (read before running R / asserting dependencies)
+
+- **Never pipe `source module_load.sh`.** Piping (e.g. `source module_load.sh | tail`) runs it in a subshell, so the environment does not persist and `Rscript`/`R` won't be found in later commands. Source it directly, then sanity-check with `which Rscript` before any heavy command. Each Bash call is a fresh shell, so re-`source` at the top of every R command (or bundle the R work into one Bash call).
+- **Verify a package is actually a dependency before treating it as one.** Check the target's `Imports`/`Depends`/`LinkingTo` (e.g. `tools::package_dependencies()` or the package's `DESCRIPTION`) rather than assuming. (A companion package shipped alongside the target is *not* necessarily a dependency.)
+- **Use the version-specific Bioconductor page** that matches the loaded module's Bioc release: `https://bioconductor.org/packages/<3.XX>/bioc/html/<pkg>.html`. The generic `/packages/release/` page describes the *current* package version, whose dependencies/`SystemRequirements` may differ from the one that installs on this R.
+- **Stale `00LOCK-<pkg>` directories** in a library (an `R CMD INSTALL` lock left by an interrupted install) cause `failed to lock directory ... Try removing .../00LOCK-<pkg>` and `cannot install` errors. Check for and remove them early — in both the workspace library (`$R_LIBS_USER`) and, when relevant, the researcher's personal library.


### PR DESCRIPTION
Encode three recurring mistakes from request INC20924136:

- templates/CLAUDE.md: new Gotchas section (don't pipe `source module_load.sh`, verify real dependencies before assuming, use the version-specific Bioconductor page, remove stale 00LOCK dirs).
- init-request.md: gate compile-heavy reproduction on having the researcher's exact command + verbatim error; triage cheap->expensive (00LOCK/permissions before the r-install-debugger agent).
- init-request.md: prefer replacing stale SUMMARY.md sections (or a single rewrite) over append-then-contradict edits.